### PR TITLE
fix(native-nav-menu): Fix visible background area on mobile expanded …

### DIFF
--- a/src/components/LeftNav/index.css
+++ b/src/components/LeftNav/index.css
@@ -107,6 +107,10 @@
     text-shadow: 0 0 black;
   }
 
+  .site-header__inner {
+    height: 100%;
+  }
+
   .navigation-drawer {
     flex-grow: 1;
   }
@@ -187,7 +191,7 @@ ul.main-nav li {
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  height: 100%;
+  /* height: 100%; */
 }
 
 .navigation-drawer {


### PR DESCRIPTION
…header

**Problem:**

<img width="420" alt="Screen Shot 2020-02-04 at 12 16 09 AM" src="https://user-images.githubusercontent.com/1409501/73729005-275dbb80-46e9-11ea-828c-e0375413374d.png">
<img width="484" alt="Screen Shot 2020-02-04 at 12 09 31 AM" src="https://user-images.githubusercontent.com/1409501/73729013-2af14280-46e9-11ea-924e-8c9a25161688.png">

**Solution:**

<img width="494" alt="Screen Shot 2020-02-04 at 12 14 28 AM" src="https://user-images.githubusercontent.com/1409501/73729104-48261100-46e9-11ea-8cc0-c89c246b43bd.png">

