### PR TITLE
Fix email name for mailchimp signup

### DIFF
--- a/src/components/MainContentWrapper/Footer/Newsletter/index.js
+++ b/src/components/MainContentWrapper/Footer/Newsletter/index.js
@@ -11,17 +11,18 @@ const Newsletter = () => {
           method="post"
           id="mc-embedded-subscribe-form"
           name="mc-embedded-subscribe-form"
-          class="validate"
+          className="validate"
           target="_blank"
-          novalidate
+          noValidate
         >
           <input type="hidden" name="form-name" value="Newsletter" />
           <input type="hidden" className="hidden" name="bot-field" />
           <input
             type="text"
-            name="email"
+            name="EMAIL"
             placeholder="Your Email"
             className="email"
+            required
           />
           <button type="submit" className="subscribe">
             Subscribe


### PR DESCRIPTION
Looks like the email is in uppercase on the mailchimp form setup